### PR TITLE
Use gnark expr and fix GoBytes limit

### DIFF
--- a/ecgo/builder/api.go
+++ b/ecgo/builder/api.go
@@ -259,7 +259,7 @@ func (builder *builder) Cmp(i1, i2 frontend.Variable) frontend.Variable {
 	bi1 := bits.ToBinary(builder, i1, bits.WithNbDigits(nbBits))
 	bi2 := bits.ToBinary(builder, i2, bits.WithNbDigits(nbBits))
 
-	res := builder.toVariableId(0)
+	res := newVariable(builder.toVariableId(0))
 
 	for i := builder.field.FieldBitLen() - 1; i >= 0; i-- {
 
@@ -272,7 +272,7 @@ func (builder *builder) Cmp(i1, i2 frontend.Variable) frontend.Variable {
 		n := builder.Select(i2i1, -1, 0)
 		m := builder.Select(i1i2, 1, n)
 
-		res = builder.toVariableId(builder.Select(builder.IsZero(res), m, res))
+		res = newVariable(builder.toVariableId(builder.Select(builder.IsZero(res), m, res)))
 
 	}
 	return res

--- a/ecgo/builder/api_assertions.go
+++ b/ecgo/builder/api_assertions.go
@@ -12,28 +12,28 @@ import (
 
 // AssertIsEqual adds an assertion that i1 is equal to i2.
 func (builder *builder) AssertIsEqual(i1, i2 frontend.Variable) {
-	x := builder.Sub(i1, i2).(variable)
+	x := builder.toVariableId(builder.Sub(i1, i2))
 	builder.constraints = append(builder.constraints, irsource.Constraint{
 		Typ: irsource.Zero,
-		Var: x.id,
+		Var: x,
 	})
 }
 
 // AssertIsDifferent constrains i1 and i2 to have different values.
 func (builder *builder) AssertIsDifferent(i1, i2 frontend.Variable) {
-	x := builder.Sub(i1, i2).(variable)
+	x := builder.toVariableId(builder.Sub(i1, i2))
 	builder.constraints = append(builder.constraints, irsource.Constraint{
 		Typ: irsource.NonZero,
-		Var: x.id,
+		Var: x,
 	})
 }
 
 // AssertIsBoolean adds an assertion that the variable is either 0 or 1.
 func (builder *builder) AssertIsBoolean(i1 frontend.Variable) {
-	x := builder.toVariable(i1)
+	x := builder.toVariableId(i1)
 	builder.constraints = append(builder.constraints, irsource.Constraint{
 		Typ: irsource.Bool,
-		Var: x.id,
+		Var: x,
 	})
 }
 
@@ -59,9 +59,9 @@ func (builder *builder) mustBeLessOrEqVar(a, bound frontend.Variable) {
 	boundBits := bits.ToBinary(builder, bound, bits.WithNbDigits(nbBits))
 
 	p := make([]frontend.Variable, nbBits+1)
-	p[nbBits] = builder.toVariable(1)
+	p[nbBits] = newVariable(builder.toVariableId(1))
 
-	zero := builder.toVariable(0)
+	zero := newVariable(builder.toVariableId(0))
 
 	for i := nbBits - 1; i >= 0; i-- {
 
@@ -78,7 +78,7 @@ func (builder *builder) mustBeLessOrEqVar(a, bound frontend.Variable) {
 
 		// (1 - t - ai) * ai == 0
 		var l frontend.Variable
-		l = builder.toVariable(1)
+		l = newVariable(builder.toVariableId(1))
 		l = builder.Sub(l, t, aBits[i])
 
 		// note if bound[i] == 1, this constraint is (1 - ai) * ai == 0
@@ -118,7 +118,7 @@ func (builder *builder) MustBeLessOrEqCst(aBits []frontend.Variable, bound *big.
 
 	p := make([]frontend.Variable, nbBits+1)
 	// p[i] == 1 → a[j] == c[j] for all j ⩾ i
-	p[nbBits] = builder.toVariable(1)
+	p[nbBits] = newVariable(builder.toVariableId(1))
 
 	for i := nbBits - 1; i >= t; i-- {
 		if bound.Bit(i) == 0 {
@@ -134,7 +134,7 @@ func (builder *builder) MustBeLessOrEqCst(aBits []frontend.Variable, bound *big.
 			l := builder.Sub(1, p[i+1])
 			l = builder.Sub(l, aBits[i])
 
-			builder.AssertIsEqual(builder.Mul(l, aBits[i]), builder.toVariable(0))
+			builder.AssertIsEqual(builder.Mul(l, aBits[i]), newVariable(builder.toVariableId(0)))
 		} else {
 			builder.AssertIsBoolean(aBits[i])
 		}

--- a/ecgo/builder/finalize.go
+++ b/ecgo/builder/finalize.go
@@ -32,7 +32,7 @@ func (builder *builder) Finalize() *irsource.Circuit {
 	return &irsource.Circuit{
 		Instructions: builder.instructions,
 		Constraints:  builder.constraints,
-		Outputs:      unwrapVariables(builder.output),
+		Outputs:      builder.output,
 		NumInputs:    builder.nbExternalInput,
 	}
 }

--- a/ecgo/builder/sub_circuit.go
+++ b/ecgo/builder/sub_circuit.go
@@ -52,18 +52,18 @@ func (parent *builder) callSubCircuit(
 	input_ []frontend.Variable,
 	f SubCircuitSimpleFunc,
 ) []frontend.Variable {
-	input := parent.toVariables(input_...)
+	input := parent.toVariableIds(input_...)
 	if _, ok := parent.root.registry.m[circuitId]; !ok {
 		n := len(input)
 		subBuilder := parent.root.newBuilder(n)
 		subInput := make([]frontend.Variable, n)
 		for i := 0; i < n; i++ {
-			subInput[i] = variable{i + 1}
+			subInput[i] = newVariable(i + 1)
 		}
 		subOutput := f(subBuilder, subInput)
-		subBuilder.output = make([]variable, len(subOutput))
+		subBuilder.output = make([]int, len(subOutput))
 		for i, v := range subOutput {
-			subBuilder.output[i] = subBuilder.toVariable(v)
+			subBuilder.output[i] = subBuilder.toVariableId(v)
 		}
 		sub := SubCircuit{
 			builder: subBuilder,
@@ -72,7 +72,7 @@ func (parent *builder) callSubCircuit(
 	}
 	sub := parent.root.registry.m[circuitId]
 
-	output := make([]variable, len(sub.builder.output))
+	output := make([]frontend.Variable, len(sub.builder.output))
 	for i := range sub.builder.output {
 		output[i] = parent.addVar()
 	}
@@ -81,16 +81,12 @@ func (parent *builder) callSubCircuit(
 		irsource.Instruction{
 			Type:       irsource.SubCircuitCall,
 			ExtraId:    circuitId,
-			Inputs:     unwrapVariables(input),
+			Inputs:     input,
 			NumOutputs: len(output),
 		},
 	)
 
-	output_ := make([]frontend.Variable, len(output))
-	for i, x := range output {
-		output_[i] = x
-	}
-	return output_
+	return output
 }
 
 // MemorizedSimpleCall memorizes a call to a SubCircuitSimpleFunc.

--- a/ecgo/builder/variable.go
+++ b/ecgo/builder/variable.go
@@ -1,17 +1,7 @@
 package builder
 
-type variable struct {
-	id int
-}
+import "github.com/PolyhedraZK/ExpanderCompilerCollection/ecgo/utils/gnarkexpr"
 
-func newVariable(id int) variable {
-	return variable{id: id}
-}
-
-func unwrapVariables(vars []variable) []int {
-	res := make([]int, len(vars))
-	for i, v := range vars {
-		res[i] = v.id
-	}
-	return res
+func newVariable(id int) gnarkexpr.Expr {
+	return gnarkexpr.NewVar(id)
 }

--- a/ecgo/utils/gnarkexpr/expr.go
+++ b/ecgo/utils/gnarkexpr/expr.go
@@ -1,0 +1,32 @@
+package gnarkexpr
+
+import (
+	"reflect"
+
+	"github.com/consensys/gnark-crypto/ecc/bn254"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/r1cs"
+)
+
+var builder frontend.Builder
+
+type Expr interface {
+	WireID() int
+}
+
+func init() {
+	var err error
+	builder, err = r1cs.NewBuilder(bn254.ID.ScalarField(), frontend.CompileConfig{})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func NewVar(x int) Expr {
+	v := builder.InternalVariable(uint32(x))
+	t := reflect.ValueOf(v).Index(0).Interface().(Expr)
+	if t.WireID() != x {
+		panic("variable id mismatch, please check gnark version")
+	}
+	return t
+}


### PR DESCRIPTION
1. Replace `builder.variable` with gnark's `expr.Term` to ensure compatibility with gnark's `IsCanonical` function. However, the current implementation accesses gnark's `internal` package. Is this a good practice?
2. Correct the issue where `C.GoBytes` uses `int32` as the size type.