### PR TITLE
typo fix hint_normalize.rs

### DIFF
--- a/expander_compiler/src/builder/hint_normalize.rs
+++ b/expander_compiler/src/builder/hint_normalize.rs
@@ -112,7 +112,7 @@ impl<'a, C: Config> InsnTransformAndExecute<'a, C, IrcIn<C>, IrcOut<C>> for Buil
                                 num_outputs: 1,
                             })
                             .unwrap();
-                        let multy = self.push_mul(*y, inv);
+                        let multi = self.push_mul(*y, inv);
                         let sub1 = self.push_sub(multy, one);
                         self.assert((), sub1);
                         InsnOut::Mul(vec![*x, inv])


### PR DESCRIPTION
## Summary of changes:
- Fixed a typo in the `hint_normalize.rs` file.

## Details:
- Corrected "multy" to "multi" to fix the typo when defining multiplication operations in the code.
