### PR TITLE
Fix to_binary in m31_utils and example

### DIFF
--- a/circuit-std-rs/src/gnark/utils.rs
+++ b/circuit-std-rs/src/gnark/utils.rs
@@ -119,7 +119,7 @@ pub fn expand_msg_xmd_variable<C: Config, B: RootAPI<C>>(
     input.extend_from_slice(&block_v);
     input.extend_from_slice(msg);
     input.push(api.constant((len_in_bytes >> 8) as u32));
-    input.push(api.constant(len_in_bytes as u32));
+    input.push(api.constant((len_in_bytes % 256) as u32));
     input.push(api.constant(0));
     input.extend_from_slice(dst);
     input.push(api.constant(size_domain as u32));

--- a/circuit-std-rs/src/sha256/m31_utils.rs
+++ b/circuit-std-rs/src/sha256/m31_utils.rs
@@ -209,7 +209,13 @@ pub fn to_binary<C: Config, B: RootAPI<C>>(
     x: Variable,
     n_bits: usize,
 ) -> Vec<Variable> {
-    api.new_hint("myhint.tobinary", &[x], n_bits)
+    let bits = api.new_hint("myhint.tobinary", &[x], n_bits);
+    for bit in bits.iter() {
+        api.assert_is_bool(*bit);
+    }
+    let sum = from_binary(api, bits.to_vec());
+    api.assert_is_equal(sum, x);
+    bits
 }
 pub fn from_binary<C: Config, B: RootAPI<C>>(api: &mut B, bits: Vec<Variable>) -> Variable {
     let mut res = api.constant(0);

--- a/ecgo/builder/api.go
+++ b/ecgo/builder/api.go
@@ -201,8 +201,6 @@ func (builder *builder) ToBinary(i1 frontend.Variable, n ...int) []frontend.Vari
 		if nbBits < 0 {
 			panic("invalid n")
 		}
-	} else {
-		panic("only one argument is supported")
 	}
 
 	return bits.ToBinary(builder, i1, bits.WithNbDigits(nbBits))

--- a/expander_compiler/src/builder/hint_normalize.rs
+++ b/expander_compiler/src/builder/hint_normalize.rs
@@ -1,5 +1,3 @@
-use core::panic;
-
 use crate::circuit::ir::common::RawConstraint;
 use crate::circuit::ir::expr;
 use crate::field::FieldArith;
@@ -183,7 +181,8 @@ impl<'a, C: Config> InsnTransformAndExecute<'a, C, IrcIn<C>, IrcOut<C>> for Buil
                 }
             }
             Commit(_) => {
-                panic!("commit is unimplemented");
+                // TODO: warn user that this is different from gnark
+                InsnOut::ConstantLike(Coef::Random)
             }
             Hint {
                 hint_id,

--- a/expander_compiler/tests/to_binary_hint.rs
+++ b/expander_compiler/tests/to_binary_hint.rs
@@ -8,7 +8,13 @@ declare_circuit!(Circuit {
 });
 
 fn to_binary<C: Config>(api: &mut impl RootAPI<C>, x: Variable, n_bits: usize) -> Vec<Variable> {
-    api.new_hint("myhint.tobinary", &[x], n_bits)
+    let bits = api.new_hint("myhint.tobinary", &[x], n_bits);
+    for bit in bits.iter() {
+        api.assert_is_bool(*bit);
+    }
+    let sum = from_binary(api, bits.to_vec());
+    api.assert_is_equal(sum, x);
+    bits
 }
 
 fn from_binary<C: Config>(api: &mut impl RootAPI<C>, bits: Vec<Variable>) -> Variable {


### PR DESCRIPTION
The example was intended to show the use of hints, but it led to some misuses, such as the use in sha256. This PR fixes this, but other code using hints needs further review.