### PR TITLE
bls12381: assert on curve for G2 extension field point

### DIFF
--- a/circuit-std-rs/src/gnark/emulated/sw_bls12381/g1.rs
+++ b/circuit-std-rs/src/gnark/emulated/sw_bls12381/g1.rs
@@ -138,19 +138,19 @@ impl G1 {
         // compute λ1 = -λ1-1*p.y/(x1-p.x)
         let ypyp = self.curve_f.add(native, &p.y, &p.y);
         let x2xp = self.curve_f.sub(native, &x2, &p.x);
-        let λ2 = self.curve_f.div(native, &ypyp, &x2xp);
-        let λ2 = self.curve_f.add(native, &λ1, &λ2);
-        let λ2 = self.curve_f.neg(native, &λ2);
+        let mut λ2 = self.curve_f.div(native, &ypyp, &x2xp);
+        λ2 = self.curve_f.add(native, &λ1, &λ2);
+        λ2 = self.curve_f.neg(native, &λ2);
 
         // compute x3 =λ2²-p.x-x3
         let λ2λ2 = self.curve_f.mul(native, &λ2, &λ2);
-        let x3 = self.curve_f.sub(native, &λ2λ2, &p.x);
-        let x3 = self.curve_f.sub(native, &x3, &x2);
+        let mut x3 = self.curve_f.sub(native, &λ2λ2, &p.x);
+        x3 = self.curve_f.sub(native, &x3, &x2);
 
         // compute y3 = λ2*(p.x - x3)-p.y
-        let y3 = self.curve_f.sub(native, &p.x, &x3);
-        let y3 = self.curve_f.mul(native, &λ2, &y3);
-        let y3 = self.curve_f.sub(native, &y3, &p.y);
+        let mut y3 = self.curve_f.sub(native, &p.x, &x3);
+        y3 = self.curve_f.mul(native, &λ2, &y3);
+        y3 = self.curve_f.sub(native, &y3, &p.y);
 
         G1Affine { x: x3, y: y3 }
     }

--- a/circuit-std-rs/src/gnark/emulated/sw_bls12381/g1.rs
+++ b/circuit-std-rs/src/gnark/emulated/sw_bls12381/g1.rs
@@ -17,13 +17,6 @@ use super::point::AffinePoint;
 const M_COMPRESSED_SMALLEST: u8 = 0b100 << 5;
 const M_COMPRESSED_LARGEST: u8 = 0b101 << 5;
 
-// TODO: refactor G1Affine, G2Affine all with AffinePoint
-// #[derive(Default, Clone)]
-// pub struct G1Affine {
-//     pub x: Element<Bls12381Fp>,
-//     pub y: Element<Bls12381Fp>,
-// }
-
 pub type G1Affine = AffinePoint<Bls12381Fp>;
 
 impl G1Affine {
@@ -177,17 +170,17 @@ impl G1 {
         z = self.double_and_add(native, &z, q);
         let mut t0 = self.double(native, &z);
         t0 = self.add(native, &z, &t0);
-        let t0 = self.double(native, &t0);
-        let t0 = self.double_and_add(native, &t0, &z);
-        let t0 = self.double_n(native, &t0, 2);
-        let t0 = self.double_and_add(native, &t0, &z);
-        let t0 = self.double_n(native, &t0, 8);
-        let t0 = self.double_and_add(native, &t0, &z);
-        let t0 = self.double_n(native, &t0, 31);
-        let z = self.add(native, &t0, &z);
-        let z = self.double_n(native, &z, 32);
-        let z = self.double_and_add(native, &z, q);
-        let z = self.double_n(native, &z, 32);
+        let mut t0 = self.double(native, &t0);
+        t0 = self.double_and_add(native, &t0, &z);
+        t0 = self.double_n(native, &t0, 2);
+        t0 = self.double_and_add(native, &t0, &z);
+        t0 = self.double_n(native, &t0, 8);
+        t0 = self.double_and_add(native, &t0, &z);
+        t0 = self.double_n(native, &t0, 31);
+        z = self.add(native, &t0, &z);
+        z = self.double_n(native, &z, 32);
+        z = self.double_and_add(native, &z, q);
+        z = self.double_n(native, &z, 32);
         z
     }
 

--- a/circuit-std-rs/src/gnark/emulated/sw_bls12381/g2.rs
+++ b/circuit-std-rs/src/gnark/emulated/sw_bls12381/g2.rs
@@ -187,10 +187,11 @@ impl G2 {
         let y2 = self.ext2.double(native, &p.y);
         let λ1 = self.ext2.div(native, &xx, &y2);
         // xr = λ1²-2p.x
-        let x2 = self
+        let mut x2 = self
             .ext2
             .mul_by_const_element(native, &p.x, &BigInt::from(2));
         let λ1λ1 = self.ext2.square(native, &λ1);
+        x2 = self.ext2.sub(native, &λ1λ1, &x2);
 
         let x1x2 = self.ext2.sub(native, &p.x, &x2);
         let mut λ2 = self.ext2.div(native, &y2, &x1x2);

--- a/circuit-std-rs/src/gnark/emulated/sw_bls12381/g2.rs
+++ b/circuit-std-rs/src/gnark/emulated/sw_bls12381/g2.rs
@@ -156,14 +156,6 @@ impl G2 {
         G2AffP::new(x3, y3)
     }
 
-    // func (g2 *G2) doubleN(p *G2Affine, n int) *G2Affine {
-    //     pn := p
-    //     for s := 0; s < n; s++ {
-    //         pn = g2.double(pn)
-    //     }
-    //     return pn
-    // }
-
     pub fn double_n<C: Config, B: RootAPI<C>>(
         &mut self,
         native: &mut B,

--- a/circuit-std-rs/src/gnark/emulated/sw_bls12381/pairing.rs
+++ b/circuit-std-rs/src/gnark/emulated/sw_bls12381/pairing.rs
@@ -469,7 +469,7 @@ impl Pairing {
         self.assert_is_on_curve(native, p.clone());
         // 2- Check P has the right subgroup order
         // [x²]ϕ(P)
-        let phi_p = self.g1.phi(native, &p);
+        let phi_p = self.g1.phi(native, p);
         let p_squared = self.g1.scalar_mul_by_seed_square(native, &phi_p);
         let neg_p_squared = self.curve.neg(native, &p_squared);
         self.g1.assert_is_equal(native, &neg_p_squared, &p_squared); // Neg returns an inverse of p. It doesn't modify p.);

--- a/circuit-std-rs/src/gnark/emulated/sw_bls12381/point.rs
+++ b/circuit-std-rs/src/gnark/emulated/sw_bls12381/point.rs
@@ -4,6 +4,7 @@ use crate::gnark::field::GField;
 use expander_compiler::frontend::{Config, RootAPI};
 use num_bigint::BigInt;
 
+#[derive(Default, Clone)]
 pub struct AffinePoint<Base: FieldParams> {
     pub x: Element<Base>,
     pub y: Element<Base>,
@@ -82,5 +83,17 @@ impl<Base: FieldParams, Scalars: FieldParams> Curve<Base, Scalars> {
         }
 
         self.base_api.assert_is_equal(builder, &left, &right);
+    }
+
+    // Neg returns an inverse of p. It doesn't modify p.
+    pub fn neg<C: Config, B: RootAPI<C>>(
+        &mut self,
+        native: &mut B,
+        p: &AffinePoint<Base>,
+    ) -> AffinePoint<Base> {
+        AffinePoint {
+            x: p.x.clone(),
+            y: self.base_api.neg(native, &p.y),
+        }
     }
 }

--- a/circuit-std-rs/tests/gnark/emulated/sw_bls12381/pairing.rs
+++ b/circuit-std-rs/tests/gnark/emulated/sw_bls12381/pairing.rs
@@ -157,6 +157,8 @@ impl Define<M31Config> for PairingCheckGKRCircuit<Variable> {
         };
         pairing.assert_is_on_curve(builder, p1_g1.clone());
         pairing.assert_is_on_curve(builder, p2_g1.clone());
+        pairing.assert_is_on_twist(builder, q1_g2.clone());
+        pairing.assert_is_on_twist(builder, q2_g2.clone());
 
         pairing
             .pairing_check(

--- a/circuit-std-rs/tests/gnark/emulated/sw_bls12381/pairing.rs
+++ b/circuit-std-rs/tests/gnark/emulated/sw_bls12381/pairing.rs
@@ -155,10 +155,10 @@ impl Define<M31Config> for PairingCheckGKRCircuit<Variable> {
                 ),
             },
         };
-        pairing.assert_is_on_curve(builder, p1_g1.clone());
-        pairing.assert_is_on_curve(builder, p2_g1.clone());
-        pairing.assert_is_on_twist(builder, q1_g2.clone());
-        pairing.assert_is_on_twist(builder, q2_g2.clone());
+        pairing.assert_is_on_g1(builder, &p1_g1);
+        pairing.assert_is_on_g1(builder, &p2_g1);
+        pairing.assert_is_on_g2(builder, &q1_g2);
+        pairing.assert_is_on_g2(builder, &q2_g2);
 
         pairing
             .pairing_check(


### PR DESCRIPTION
this PR aims to add g2 point on curve verification for bl12381 curve circuit.
BTW, rename some existing methods "g2_xxx" , remove g2 prefix since the methods are all implemented in G2 struct. no need to add such prefix, not good convention.

also refer to issue #89 
previous PR #95 have supported G1 points verification.