### PR TITLE
combine rangeproof api

### DIFF
--- a/circuit-std-rs/src/gnark/field.rs
+++ b/circuit-std-rs/src/gnark/field.rs
@@ -191,13 +191,8 @@ impl<T: FieldParams> GField<T> {
                 limb_nb_bits = ((T::modulus().bits() - 1) % T::bits_per_limb() as u64) + 1;
             }
             //range check
-            if limb_nb_bits > 8 {
-                self.table
-                    .rangeproof(native, a.limbs[i], limb_nb_bits as usize);
-            } else {
-                self.table
-                    .rangeproof_onechunk(native, a.limbs[i], limb_nb_bits as usize);
-            }
+            self.table
+                .rangeproof(native, a.limbs[i], limb_nb_bits as usize);
         }
     }
     pub fn wrap_hint<C: Config, B: RootAPI<C>>(

--- a/circuit-std-rs/src/logup.rs
+++ b/circuit-std-rs/src/logup.rs
@@ -360,6 +360,10 @@ impl LogUpRangeProofTable {
     }
 
     pub fn rangeproof<C: Config, B: RootAPI<C>>(&mut self, builder: &mut B, a: Variable, n: usize) {
+        if n <= self.rangeproof_bits {
+            self.rangeproof_onechunk(builder, a, n);
+            return;
+        }
         //add a shift value
         let mut n = n;
         let mut new_a = a;


### PR DESCRIPTION
Combine rangeproof and rangeproof_onechunk api. 
Now, users don't need to consider whether the query range is larger than the table range.