### PR TITLE
Ignore pairing test by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         run: brew install openmpi
       - if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install libopenmpi-dev -y
-      - run: cargo test -- --skip pairing_random_test
+      - run: cargo test
 
   test-rust-avx512:
     runs-on: 7950x3d

--- a/circuit-std-rs/tests/gnark/emulated/sw_bls12381/pairing.rs
+++ b/circuit-std-rs/tests/gnark/emulated/sw_bls12381/pairing.rs
@@ -402,6 +402,7 @@ fn test_pairing_check_gkr() {
 }
 
 #[test]
+#[ignore]
 fn pairing_random_test() {
     let mut hint_registry = HintRegistry::<M31>::new();
     register_hint(&mut hint_registry);


### PR DESCRIPTION
In local tests, it's still annoying to run `cargo test -- --skip xxx`. I think it's better to just mark it `#[ignore]`.