### PR TITLE
Zkcuda transpose

### DIFF
--- a/expander_compiler/src/zkcuda/context.rs
+++ b/expander_compiler/src/zkcuda/context.rs
@@ -9,9 +9,10 @@ use crate::{
     utils::pool::Pool,
 };
 
+use super::proving_system::compute_bit_position;
 use super::vec_shaped::{flatten_shaped_pack_simd, unflatten_shaped_unpack_simd};
 use super::{
-    kernel::{shape_prepend, Kernel, Shape},
+    kernel::{shape_prepend, BitOrder, Kernel, Shape},
     proof::{ComputationGraph, ProofTemplate},
     proving_system::{ExpanderGKRProvingSystem, ProvingSystem},
     vec_shaped::{flatten_shaped, unflatten_shaped, VecShaped},
@@ -30,6 +31,7 @@ pub struct DeviceMemoryHandleRaw {
     pub id: usize,
     pub broadcast_type: BroadcastType,
     pub shape: Shape,
+    pub bit_order: BitOrder,
 }
 
 pub type DeviceMemoryHandle = Option<DeviceMemoryHandleRaw>;
@@ -198,6 +200,9 @@ fn check_reshape_compat(shape: &[usize], new_shape: &[usize]) {
 
 pub trait Reshape {
     fn reshape(&self, new_shape: &[usize]) -> Self;
+
+    // THIS IS A TEMPORARY SOLUTION, WILL CHANGE API IN THE FUTURE
+    fn reorder_bits(&self, bit_order: &[usize]) -> Self;
 }
 
 impl Reshape for DeviceMemoryHandle {
@@ -211,6 +216,27 @@ impl Reshape for DeviceMemoryHandle {
             id: handle.id,
             broadcast_type: handle.broadcast_type,
             shape: Some(new_shape.to_vec()),
+            bit_order: handle.bit_order,
+        })
+    }
+
+    fn reorder_bits(&self, bit_order: &[usize]) -> Self {
+        let handle = ensure_handle(self.clone());
+        let combined_bit_order = match handle.bit_order {
+            Some(ref x) => {
+                let mut new_bit_order = vec![0; x.len()];
+                for i in 0..x.len() {
+                    new_bit_order[i] = x[bit_order[i]];
+                }
+                Some(new_bit_order)
+            }
+            None => Some(bit_order.to_vec()),
+        };
+        Some(DeviceMemoryHandleRaw {
+            id: handle.id,
+            broadcast_type: handle.broadcast_type,
+            shape: handle.shape,
+            bit_order: combined_bit_order,
         })
     }
 }
@@ -242,6 +268,7 @@ impl<C: Config, P: ProvingSystem<C>, H: HintCaller<CircuitField<C>>> Context<C, 
             id: self.device_memories.len() - 1,
             broadcast_type,
             shape,
+            bit_order: None,
         })
     }
 
@@ -479,18 +506,34 @@ impl<C: Config, P: ProvingSystem<C>, H: HintCaller<CircuitField<C>>> Context<C, 
                 let device_memory = &self.device_memories[input.as_ref().unwrap().id];
                 let offset = ws_input.input_offset.unwrap();
                 if is_broadcast[i] {
-                    for (i, x) in device_memory.values.iter().enumerate() {
-                        ws_inputs[offset + i] = *x;
+                    if let Some(bit_order) = input.as_ref().unwrap().bit_order.clone() {
+                        for i in 0..ws_input.len {
+                            ws_inputs[offset + i] =
+                                device_memory.values[compute_bit_position(&bit_order, i)];
+                        }
+                    } else {
+                        for (i, x) in device_memory.values.iter().enumerate() {
+                            ws_inputs[offset + i] = *x;
+                        }
                     }
                 } else {
-                    for (i, x) in device_memory
-                        .values
-                        .iter()
-                        .skip(parallel_i * next_power_of_two(ws_input.len))
-                        .take(ws_input.len)
-                        .enumerate()
-                    {
-                        ws_inputs[offset + i] = *x;
+                    if let Some(bit_order) = input.as_ref().unwrap().bit_order.clone() {
+                        for i in 0..ws_input.len {
+                            ws_inputs[offset + i] = device_memory.values[compute_bit_position(
+                                &bit_order,
+                                i + parallel_i * next_power_of_two(ws_input.len),
+                            )];
+                        }
+                    } else {
+                        for (i, x) in device_memory
+                            .values
+                            .iter()
+                            .skip(parallel_i * next_power_of_two(ws_input.len))
+                            .take(ws_input.len)
+                            .enumerate()
+                        {
+                            ws_inputs[offset + i] = *x;
+                        }
                     }
                 }
             }
@@ -559,6 +602,10 @@ impl<C: Config, P: ProvingSystem<C>, H: HintCaller<CircuitField<C>>> Context<C, 
         self.proof_templates.push(ProofTemplate {
             kernel_id,
             commitment_indices: handles.iter().map(|x| x.id).collect(),
+            commitment_bit_orders: handles
+                .iter()
+                .map(|x| x.bit_order.clone())
+                .collect::<Vec<_>>(),
             parallel_count,
             is_broadcast: lc_is_broadcast,
         });
@@ -619,6 +666,7 @@ impl<C: Config, P: ProvingSystem<C>, H: HintCaller<CircuitField<C>>> Context<C, 
                         .iter()
                         .map(|x| &self.device_memories[*x].values[..])
                         .collect::<Vec<_>>(),
+                    &template.commitment_bit_orders,
                     next_power_of_two(template.parallel_count),
                     &template.is_broadcast,
                 )
@@ -659,6 +707,7 @@ impl<C: Config> ComputationGraph<C> {
                 &self.kernels[template.kernel_id],
                 proof,
                 commitments_kernel,
+                &template.commitment_bit_orders,
                 next_power_of_two(template.parallel_count),
                 &template.is_broadcast,
             ) {

--- a/expander_compiler/src/zkcuda/kernel.rs
+++ b/expander_compiler/src/zkcuda/kernel.rs
@@ -41,6 +41,14 @@ pub fn shape_prepend(shape: &Shape, x: usize) -> Shape {
     }
 }
 
+/*
+Bit order definition:
+Suppose bit_order = [a_0, a_1, a_2, ...]
+Then when we read the i-th position, where i = sum(b_j * 2^j), b_j = 0 or 1,
+we will read the j-th position, where j = sum(b_j * 2^(a_j)).
+*/
+pub type BitOrder = Option<Vec<usize>>;
+
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, ExpSerde)]
 pub struct WitnessSolverIOVec {
     pub len: usize,

--- a/expander_compiler/src/zkcuda/proof.rs
+++ b/expander_compiler/src/zkcuda/proof.rs
@@ -1,6 +1,6 @@
 use serdes::ExpSerde;
 
-use super::kernel::Kernel;
+use super::kernel::{BitOrder, Kernel};
 
 use crate::circuit::config::Config;
 
@@ -8,6 +8,7 @@ use crate::circuit::config::Config;
 pub struct ProofTemplate {
     pub kernel_id: usize,
     pub commitment_indices: Vec<usize>,
+    pub commitment_bit_orders: Vec<BitOrder>,
     pub parallel_count: usize,
     pub is_broadcast: Vec<bool>,
 }

--- a/expander_compiler/src/zkcuda/proving_system/common.rs
+++ b/expander_compiler/src/zkcuda/proving_system/common.rs
@@ -59,3 +59,59 @@ pub fn prepare_inputs<C: Config>(
     }
     lc_input
 }
+
+pub fn compute_bit_position(bit_order: &[usize], i: usize) -> usize {
+    let mut res = 0;
+    for (j, x) in bit_order.iter().enumerate() {
+        if i >> j & 1 == 1 {
+            res += 1 << x;
+        }
+    }
+    res
+}
+
+pub fn prepare_inputs_bit_order<C: Config>(
+    layered_circuit: &Circuit<C, NormalInputType>,
+    partition_info: &[LayeredCircuitInputVec],
+    values: &[&[SIMDField<C>]],
+    bit_orders: &[Option<Vec<usize>>],
+    is_broadcast: &[bool],
+    parallel_index: usize,
+) -> Vec<SIMDField<C>> {
+    let mut lc_input = vec![SIMDField::<C>::zero(); layered_circuit.input_size()];
+    for (((input, value), ib), bit_order) in partition_info
+        .iter()
+        .zip(values.iter())
+        .zip(is_broadcast)
+        .zip(bit_orders)
+    {
+        if *ib {
+            if let Some(bit_order) = bit_order {
+                for i in 0..input.len {
+                    lc_input[input.offset + i] = value[compute_bit_position(bit_order, i)];
+                }
+            } else {
+                for (i, x) in value.iter().enumerate() {
+                    lc_input[input.offset + i] = *x;
+                }
+            }
+        } else {
+            if let Some(bit_order) = bit_order {
+                for i in 0..input.len {
+                    lc_input[input.offset + i] =
+                        value[compute_bit_position(bit_order, i + parallel_index * input.len)];
+                }
+            } else {
+                for (i, x) in value
+                    .iter()
+                    .skip(parallel_index * input.len)
+                    .take(input.len)
+                    .enumerate()
+                {
+                    lc_input[input.offset + i] = *x;
+                }
+            }
+        }
+    }
+    lc_input
+}

--- a/expander_compiler/src/zkcuda/proving_system/dummy.rs
+++ b/expander_compiler/src/zkcuda/proving_system/dummy.rs
@@ -3,7 +3,7 @@ use serdes::ExpSerde;
 use crate::circuit::config::{Config, SIMDField};
 
 use super::super::kernel::Kernel;
-use super::{check_inputs, prepare_inputs, Commitment, Proof, ProvingSystem};
+use super::{check_inputs, prepare_inputs_bit_order, Commitment, Proof, ProvingSystem};
 
 // dummy implementation of these traits
 
@@ -74,16 +74,18 @@ impl<C: Config> ProvingSystem<C> for DummyProvingSystem<C> {
         _commitments: &[Self::Commitment],
         _commitments_extra_info: &[Self::CommitmentExtraInfo],
         commitments_values: &[&[SIMDField<C>]],
+        commitments_bit_order: &[Option<Vec<usize>>],
         parallel_count: usize,
         is_broadcast: &[bool],
     ) -> DummyProof {
         check_inputs(kernel, commitments_values, parallel_count, is_broadcast);
         let mut res = vec![];
         for i in 0..parallel_count {
-            let lc_input = prepare_inputs(
+            let lc_input = prepare_inputs_bit_order(
                 &kernel.layered_circuit,
                 &kernel.layered_circuit_input,
                 commitments_values,
+                commitments_bit_order,
                 is_broadcast,
                 i,
             );
@@ -104,16 +106,18 @@ impl<C: Config> ProvingSystem<C> for DummyProvingSystem<C> {
         kernel: &Kernel<C>,
         proof: &Self::Proof,
         commitments: &[Self::Commitment],
+        commitments_bit_order: &[Option<Vec<usize>>],
         parallel_count: usize,
         is_broadcast: &[bool],
     ) -> bool {
         let values = commitments.iter().map(|c| &c.vals[..]).collect::<Vec<_>>();
         check_inputs(kernel, &values, parallel_count, is_broadcast);
         for i in 0..parallel_count {
-            let lc_input = prepare_inputs(
+            let lc_input = prepare_inputs_bit_order(
                 &kernel.layered_circuit,
                 &kernel.layered_circuit_input,
                 &values,
+                commitments_bit_order,
                 is_broadcast,
                 i,
             );

--- a/expander_compiler/src/zkcuda/proving_system/expander_gkr.rs
+++ b/expander_compiler/src/zkcuda/proving_system/expander_gkr.rs
@@ -197,6 +197,7 @@ impl<C: GKREngine, ECCConfig: Config<FieldConfig = C::FieldConfig>> ProvingSyste
         _commitments: &[Self::Commitment],
         commitments_extra_info: &[Self::CommitmentExtraInfo],
         commitments_values: &[&[SIMDField<C>]],
+        _commitments_bit_order: &[Option<Vec<usize>>],
         parallel_count: usize,
         is_broadcast: &[bool],
     ) -> Self::Proof {
@@ -273,6 +274,7 @@ impl<C: GKREngine, ECCConfig: Config<FieldConfig = C::FieldConfig>> ProvingSyste
         kernel: &Kernel<ECCConfig>,
         proof: &Self::Proof,
         commitments: &[Self::Commitment],
+        _commitments_bit_order: &[Option<Vec<usize>>],
         parallel_count: usize,
         is_broadcast: &[bool],
     ) -> bool {

--- a/expander_compiler/src/zkcuda/proving_system/expander_gkr_parallelized.rs
+++ b/expander_compiler/src/zkcuda/proving_system/expander_gkr_parallelized.rs
@@ -85,6 +85,7 @@ impl<C: GKREngine, ECCConfig: Config<FieldConfig = C::FieldConfig>> ProvingSyste
         commitments: &[Self::Commitment],
         commitments_extra_info: &[Self::CommitmentExtraInfo],
         commitments_values: &[&[SIMDField<C>]],
+        _commitments_bit_order: &[Option<Vec<usize>>],
         parallel_count: usize,
         is_broadcast: &[bool],
     ) -> Self::Proof {
@@ -95,6 +96,7 @@ impl<C: GKREngine, ECCConfig: Config<FieldConfig = C::FieldConfig>> ProvingSyste
                 commitments,
                 commitments_extra_info,
                 commitments_values,
+                _commitments_bit_order,
                 parallel_count,
                 is_broadcast,
             )
@@ -120,6 +122,7 @@ impl<C: GKREngine, ECCConfig: Config<FieldConfig = C::FieldConfig>> ProvingSyste
         kernel: &Kernel<ECCConfig>,
         proof: &Self::Proof,
         commitments: &[Self::Commitment],
+        _commitments_bit_order: &[Option<Vec<usize>>],
         parallel_count: usize,
         is_broadcast: &[bool],
     ) -> bool {

--- a/expander_compiler/src/zkcuda/proving_system/traits.rs
+++ b/expander_compiler/src/zkcuda/proving_system/traits.rs
@@ -32,6 +32,7 @@ pub trait ProvingSystem<C: Config> {
         commitments: &[Self::Commitment],
         commitments_extra_info: &[Self::CommitmentExtraInfo],
         commitments_values: &[&[SIMDField<C>]],
+        commitments_bit_order: &[Option<Vec<usize>>],
         parallel_count: usize,
         is_broadcast: &[bool],
     ) -> Self::Proof;
@@ -41,6 +42,7 @@ pub trait ProvingSystem<C: Config> {
         kernel: &Kernel<C>,
         proof: &Self::Proof,
         commitments: &[Self::Commitment],
+        commitments_bit_order: &[Option<Vec<usize>>],
         parallel_count: usize,
         is_broadcast: &[bool],
     ) -> bool;

--- a/expander_compiler/tests/zkcuda_transpose.rs
+++ b/expander_compiler/tests/zkcuda_transpose.rs
@@ -1,0 +1,62 @@
+use expander_compiler::frontend::*;
+use expander_compiler::zkcuda::proving_system::DummyProvingSystem;
+use expander_compiler::zkcuda::{context::*, kernel::*};
+
+#[kernel]
+fn sum<C: Config>(api: &mut API<C>, a: &[InputVariable; 16], b: &mut OutputVariable) {
+    let mut sum = api.constant(0);
+    for i in 0..16 {
+        sum = api.add(sum, a[i]);
+    }
+    *b = sum;
+}
+
+#[test]
+fn zkcuda_transpose() {
+    let kernel_sum: Kernel<M31Config> = compile_sum().unwrap();
+
+    let mut ctx: Context<M31Config, DummyProvingSystem<M31Config>> = Context::default();
+
+    let mut mat: Vec<Vec<M31>> = vec![];
+    for i in 0..16 {
+        mat.push(vec![]);
+        for _ in 0..16 {
+            mat[i].push(M31::from((i == 0) as u32));
+        }
+    }
+
+    // Let the matrix be 4x4x4x4 [a,b,c,d], it has value 1 only when a=b=0
+    let mat = ctx.copy_to_device(&mat, false);
+    let mat_clone = mat.clone();
+    let mut res1 = None;
+    call_kernel!(ctx, kernel_sum, mat_clone, mut res1);
+    let res1: Vec<M31> = ctx.copy_to_host(res1);
+    let expected_res1 = vec![16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+    // Now it's [c,d,a,b]
+    let mat = mat.reorder_bits(&[4, 5, 6, 7, 0, 1, 2, 3]);
+    let mat_clone = mat.clone();
+    let mut res2 = None;
+    call_kernel!(ctx, kernel_sum, mat_clone, mut res2);
+    let res2: Vec<M31> = ctx.copy_to_host(res2);
+    let expected_res2 = vec![1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+
+    // Now it's [b,c,d,a]
+    let mat = mat.reorder_bits(&[2, 3, 4, 5, 6, 7, 0, 1]);
+    let mat_clone = mat.clone();
+    let mut res3 = None;
+    call_kernel!(ctx, kernel_sum, mat_clone, mut res3);
+    let res3: Vec<M31> = ctx.copy_to_host(res3);
+    let expected_res3 = vec![4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+    for i in 0..16 {
+        assert_eq!(res1[i], M31::from(expected_res1[i]));
+        assert_eq!(res2[i], M31::from(expected_res2[i]));
+        assert_eq!(res3[i], M31::from(expected_res3[i]));
+    }
+
+    let computation_graph = ctx.to_computation_graph();
+    let (prover_setup, verifier_setup) = ctx.proving_system_setup(&computation_graph);
+    let proof = ctx.to_proof(&prover_setup);
+    assert!(computation_graph.verify(&proof, &verifier_setup));
+}


### PR DESCRIPTION
## Transpose

Suppose we have an `n x m` matrix `a[i][j]`, where both `n` and `m` are powers of 2 (i.e., `n = 2^k`, `m = 2^k`).  
The current memory layout is:

```
[a[0][0], a[0][1], a[0][2], ..., a[0][m-1],
 a[1][0], ..., 
 a[n-1][m-1]]
```

We want to efficiently convert it into:

```
[a[0][0], a[1][0], a[2][0], ..., a[n-1][0],
 a[0][1], a[1][1], ..., a[n-1][m-1]]
```

i.e., perform a transpose in memory layout with **very low cost**.

## Definition

Assume we have a block of device memory of size `n = 2^k`, containing data:

```
a[0], a[1], ..., a[n-1]
```

We define a **transpose** operation as:

- Input: a permutation `b = [b_0, b_1, ..., b_{k-1}]` of the bit positions `[0, 1, ..., k-1]`
- Define a function `f(i)` as follows:
  - Let `i` be a `k`-bit integer: `i = c_0 + (c_1 << 1) + (c_2 << 2) + ... + (c_{k-1} << (k-1))`
  - Then: `f(i) = c_0 << b_0 + c_1 << b_1 + ... + c_{k-1} << b_{k-1}`  
    (i.e., rearrange the bits of `i` according to the permutation `b`)
- The transposed data becomes:
  ```
  a[f(0)], a[f(1)], ..., a[f(n-1)]
  ```

## Current Status

This PR currently adds a frontend function `reorder_bits`, which provides a temporary way to apply bit-level index permutations. This implementation is mainly for debugging and testing the backend, and will be replaced with a better-designed API in the future.

The corresponding backend logic has been implemented for the `DummyProvingSystem`.