### PR TITLE
add optimistic inv

### DIFF
--- a/expander_compiler/src/builder/basic.rs
+++ b/expander_compiler/src/builder/basic.rs
@@ -9,7 +9,7 @@ use crate::{
             expr::{Expression, LinComb, Term, VarSpec},
         },
     },
-    field::FieldArith,
+    field::{Field, FieldArith},
     frontend::CircuitField,
     utils::{error::Error, pool::Pool},
 };
@@ -278,7 +278,7 @@ impl<'a, C: Config, IrcIn: IrConfig<Config = C>, IrcOut: IrConfig<Config = C>>
                         IrcOut::Instruction::from_kx_plus_b(ovr.x, k, b);
                 }
                 None => {
-                    let coef_inv = coef.inv().unwrap();
+                    let coef_inv = coef.optimistic_inv().unwrap();
                     self.mid_to_out[eid] = Some(OutVarRef {
                         x: id,
                         k: coef_inv,
@@ -436,7 +436,7 @@ fn strip_constants<C: Config>(
         return (Expression::default(), CircuitField::<C>::zero(), cst);
     }
     let v = e[0].coef;
-    let vi = v.inv().unwrap();
+    let vi = v.optimistic_inv().unwrap();
     for term in e.iter_mut() {
         term.coef *= vi;
     }

--- a/expander_compiler/src/builder/final_build_opt.rs
+++ b/expander_compiler/src/builder/final_build_opt.rs
@@ -17,7 +17,7 @@ use crate::{
         },
         layered::Coef,
     },
-    field::FieldArith,
+    field::{Field, FieldArith},
     frontend::CircuitField,
     utils::{error::Error, pool::Pool},
 };
@@ -140,7 +140,7 @@ impl<C: Config> Builder<C> {
         if idx == self.mid_var_coefs.len() {
             self.mid_var_coefs.push(MidVarCoef {
                 k: coef,
-                kinv: coef.inv().unwrap(),
+                kinv: coef.optimistic_inv().unwrap(),
                 b: constant,
             });
             self.mid_var_layer.push(self.layer_of_expr(&e) + 1);
@@ -178,7 +178,7 @@ impl<C: Config> Builder<C> {
         if idx == self.mid_var_coefs.len() {
             self.mid_var_coefs.push(MidVarCoef {
                 k: coef,
-                kinv: coef.inv().unwrap(),
+                kinv: coef.optimistic_inv().unwrap(),
                 b: constant,
             });
             self.mid_var_layer.push(self.layer_of_expr(&e) + 1);
@@ -507,7 +507,7 @@ fn strip_constants<C: Config>(
         return (Expression::default(), CircuitField::<C>::one(), cst);
     }
     let v = e[0].coef;
-    let vi = v.inv().unwrap();
+    let vi = v.optimistic_inv().unwrap();
     for term in e.iter_mut() {
         term.coef *= vi;
     }

--- a/expander_compiler/src/field.rs
+++ b/expander_compiler/src/field.rs
@@ -5,7 +5,17 @@ pub use goldilocks::{Goldilocks, Goldilocksx8};
 pub use mersenne31::{M31x16, M31};
 use serdes::ExpSerde;
 
-pub trait Field: FieldArith + ExpSerde {}
+pub trait Field: FieldArith + ExpSerde {
+    fn optimistic_inv(&self) -> Option<Self> {
+        if self.is_zero() {
+            None
+        } else if *self == Self::ONE {
+            Some(Self::ONE)
+        } else {
+            self.inv()
+        }
+    }
+}
 
 impl Field for BN254Fr {}
 impl Field for GF2 {}


### PR DESCRIPTION
In compilation process, `inv(1)` is called too many times. By adding the optimistic path, it gains 10%-20% improvement in compilation time of some circuits.